### PR TITLE
Load helper methods manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Or install it yourself as:
 
     $ gem install rspec_structure_matcher
 
+Then mixin/include the helper methods into your RSpec tests by adding them to the `RSpec.configure` block, usually found in `spec_helper.rb` or `rails_helper.rb`:
+
+    RSpec.configure do |config|
+      config.include HaveStructureMatcher::Methods
+    end
+
 ## Usage
 
 Define an expected response structure:

--- a/lib/rspec_structure_matcher.rb
+++ b/lib/rspec_structure_matcher.rb
@@ -1,2 +1,3 @@
+require 'rspec/expectations'
 require 'support_methods'
 require 'have_structure_matcher'

--- a/lib/support_methods.rb
+++ b/lib/support_methods.rb
@@ -55,7 +55,3 @@ module HaveStructureMatcher
     end
   end
 end
-
-RSpec.configure do |config|
-  config.include HaveStructureMatcher::Methods
-end


### PR DESCRIPTION
Without this, Gem load order could sometimes result in undefined constant errors.